### PR TITLE
Fix #3 by importing `collections.abc.Iterable`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,10 +30,9 @@ package_dir =
 # install_requires = numpy; scipy
 install_requires = 
   hypothesis
-  meza
-  multimethod 
+  multimethod
 # Add here test requirements (semicolon-separated)
-tests_require = pytest; pytest-cov
+tests_require = pytest; pytest-cov; meza
 
 [options.packages.find]
 where = src

--- a/src/hypothesis_csv/_data_rows.py
+++ b/src/hypothesis_csv/_data_rows.py
@@ -1,5 +1,6 @@
 import functools
 import string
+from collections.abc import Iterable
 
 from hypothesis.errors import InvalidArgument
 from hypothesis.strategies import composite, integers, sampled_from, floats, text
@@ -18,7 +19,7 @@ def get_columns(draw, columns):
 
 
 @overload
-def get_columns(draw, columns: isa(collections.Iterable)):
+def get_columns(draw, columns: isa(Iterable)):
     return columns
 
 

--- a/src/hypothesis_csv/type_utils.py
+++ b/src/hypothesis_csv/type_utils.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterable
+
 from multimethod import isa
-import collections
 
 # utils to support multimethod dispatching
 
@@ -8,4 +9,4 @@ def is_none(x):
 
 
 def is_seq(x):
-    return isa(collections.Iterable)(x) and not isa(str)(x)
+    return isa(Iterable)(x) and not isa(str)(x)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -98,24 +98,28 @@ def test_csv_header_int(data, kwargs):
 @given(data=st.data())
 def test_csv_columns_seq(data):
     columns = [
-        st.text(min_size=1, max_size=100, alphabet=string.ascii_lowercase + string.ascii_uppercase + string.digits),
-        st.integers(), st.floats(min_value=1.2, max_value=100.12)]
+        st.text(min_size=1, max_size=100, alphabet=string.ascii_lowercase + string.ascii_uppercase),
+        st.integers(),
+        st.floats(min_value=1.2, max_value=100.12),
+    ]
 
-    csv_string = data.draw(csv(columns=columns, lines=40))
+    csv_string = data.draw(csv(columns=columns, lines=100))
     records = csv2records(csv_string, has_header=False)
     detected_types = detect_types(records)[1]
     types = list(map(lambda x: x["type"], detected_types["types"]))
-    assert len(records) == 40
+    assert len(records) == 100
     assert types == ["text", "int", "float"]
 
 
 @given(data=st.data())
 def test_csv_columns_and_header_seq(data):
     columns = [
-        st.text(min_size=1, max_size=100, alphabet=string.ascii_lowercase + string.ascii_uppercase + string.digits),
-        st.integers(), st.floats(min_value=1.2, max_value=100.12)]
+        st.text(min_size=1, max_size=100, alphabet=string.ascii_lowercase + string.ascii_uppercase),
+        st.integers(),
+        st.floats(min_value=1.2, max_value=100.12),
+    ]
     header = ["x", "y", "z"]
-    csv_string = data.draw(csv(header=header, columns=columns, lines=10))
+    csv_string = data.draw(csv(header=header, columns=columns, lines=100))
     records = csv2records(csv_string)
     detected_types = detect_types(records)[1]
     types = list(map(lambda x: x["type"], detected_types["types"]))

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -15,7 +15,6 @@ def csv2records(string, has_header=True, delimiter=","):
     return list(read_csv(StringIO(string), has_header=has_header, delimiter=delimiter))
 
 
-@settings(use_coverage=False)
 @given(data=st.data(), lines_num=st.integers(min_value=0, max_value=200))
 def test_data_rows_fixed_lines_num(data, lines_num):
     rows = data.draw(data_rows(lines=lines_num, columns=[st.integers(), st.integers(), st.floats()]))
@@ -23,7 +22,6 @@ def test_data_rows_fixed_lines_num(data, lines_num):
     assert all([len(r) == 3 for r in rows])
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_data_rows_random_lines_num(data):
     rows = data.draw(data_rows(columns=[st.integers(), st.integers(), st.floats()]))
@@ -31,7 +29,6 @@ def test_data_rows_random_lines_num(data):
     assert all([len(r) == 3 for r in rows])
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_data_rows_all_random(data):
     rows = data.draw(data_rows())
@@ -39,7 +36,6 @@ def test_data_rows_all_random(data):
     assert all([len(r) >= 1 for r in rows])
 
 
-@settings(use_coverage=False)
 @given(data=st.data(), columns_num=st.integers(min_value=1, max_value=10))
 def test_data_rows_fixed_column_num(data, columns_num):
     rows = data.draw(data_rows(columns=columns_num))
@@ -47,7 +43,6 @@ def test_data_rows_fixed_column_num(data, columns_num):
     assert all([len(r) == columns_num and all([type(field) in [int, str, float]] for field in r) for r in rows])
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_csv_all_random(data):
     csv_string = data.draw(csv())
@@ -55,7 +50,6 @@ def test_csv_all_random(data):
     assert isinstance(csv_string, str)
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_csv_header_simple(data):
     header = ["abc", "cde"]
@@ -66,7 +60,6 @@ def test_csv_header_simple(data):
     assert extracted_header == header
 
 
-@settings(use_coverage=False)
 @given(data=st.data(), header=st.lists(st.text(min_size=1, max_size=5,
                                                alphabet=string.ascii_lowercase + string.ascii_uppercase + string.digits),
                                        min_size=1, max_size=5))
@@ -78,7 +71,6 @@ def test_csv_header_property(data, header):
     assert extracted_header == header
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_csv_lines_fixed(data):
     lines = 10
@@ -103,7 +95,6 @@ def test_csv_header_int(data, kwargs):
     assert len(extracted_header) == list(kwargs.values())[0]
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_csv_columns_seq(data):
     columns = [
@@ -118,7 +109,6 @@ def test_csv_columns_seq(data):
     assert types == ["text", "int", "float"]
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_csv_columns_and_header_seq(data):
     columns = [
@@ -136,7 +126,6 @@ def test_csv_columns_and_header_seq(data):
     assert extracted_header == header
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_csv_dialect_tab(data):
     header = ["abc", "cde"]
@@ -148,7 +137,6 @@ def test_csv_dialect_tab(data):
     assert len(records) == 5
 
 
-@settings(use_coverage=False)
 @given(data=st.data())
 def test_csv_dialect_none(data):
     header = ["abc", "cde"]

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -2,7 +2,7 @@ import string
 from io import StringIO
 
 import pytest
-from hypothesis import settings, given
+from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.errors import InvalidArgument
 from meza.io import read_csv


### PR DESCRIPTION
Fixes compatibility with Python 3.10 by removing references to the deprecated (and removed in 3.10) `collections.Iterable` alias and importing `Iterable` from `collections.abc`.

Also fixes the test suite to work with more recent versions of Hypothesis and Meza.

Fixes #3.